### PR TITLE
feat : 리뷰 좋아요/스크랩 redis 전략 수정

### DIFF
--- a/src/main/java/com/booklog/review/config/RedisConfig.java
+++ b/src/main/java/com/booklog/review/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.booklog.review.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(factory);
+
+        //Optional: Serializer 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        // Jackson2JsonRedisSerializer : Jackson 라이브러리를 사용하여 Java 객체를 JSON 형식으로 직렬화/역직렬화
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+
+        // Hash 키와 값에 대한 직렬화
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/booklog/review/detail/dto/ReviewDetail.java
+++ b/src/main/java/com/booklog/review/detail/dto/ReviewDetail.java
@@ -49,14 +49,4 @@ public class ReviewDetail {
 			.comments(reviewDetailEntity.getComments())
 			.build();
 	}
-
-	public ReviewDetail countLikes(long likesCount){
-		this.likesCount = likesCount;
-		return this;
-	}
-
-	public ReviewDetail countScraps(long scrapsCount){
-		this.scrapsCount = scrapsCount;
-		return this;
-	}
 }

--- a/src/main/java/com/booklog/review/detail/repository/MongoTemplateReviewDetailRepository.java
+++ b/src/main/java/com/booklog/review/detail/repository/MongoTemplateReviewDetailRepository.java
@@ -1,0 +1,8 @@
+package com.booklog.review.detail.repository;
+
+public interface MongoTemplateReviewDetailRepository {
+	void incrementLikesCountByReviewId(String reviewId);
+	void incrementScrapsCountByReviewId(String reviewId);
+	void decrementLikesCountByReviewId(String reviewId);
+	void decrementScrapsCountByReviewId(String reviewId);
+}

--- a/src/main/java/com/booklog/review/detail/repository/MongoTemplateReviewDetailRepositoryImpl.java
+++ b/src/main/java/com/booklog/review/detail/repository/MongoTemplateReviewDetailRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.booklog.review.detail.repository;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import com.booklog.review.detail.entity.ReviewDetailEntity;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MongoTemplateReviewDetailRepositoryImpl implements MongoTemplateReviewDetailRepository{
+	private final MongoTemplate mongoTemplate;
+	@Override
+	public void incrementLikesCountByReviewId(String reviewId) {
+		Query query = new Query(Criteria.where("_id").is(reviewId));
+		Update update = new Update().inc("likesCount", 1);
+		mongoTemplate.updateFirst(query, update, ReviewDetailEntity.class);
+	}
+
+	@Override
+	public void incrementScrapsCountByReviewId(String reviewId) {
+		Query query = new Query(Criteria.where("_id").is(reviewId));
+		Update update = new Update().inc("scrapsCount", 1);
+		mongoTemplate.updateFirst(query, update, ReviewDetailEntity.class);
+	}
+
+	@Override
+	public void decrementLikesCountByReviewId(String reviewId) {
+		Query query = new Query(Criteria.where("_id").is(reviewId));
+		Update update = new Update().inc("likesCount", -1);
+		mongoTemplate.updateFirst(query, update, ReviewDetailEntity.class);
+	}
+
+	@Override
+	public void decrementScrapsCountByReviewId(String reviewId) {
+		Query query = new Query(Criteria.where("_id").is(reviewId));
+		Update update = new Update().inc("scrapsCount", -1);
+		mongoTemplate.updateFirst(query, update, ReviewDetailEntity.class);
+	}
+}

--- a/src/main/java/com/booklog/review/detail/service/ReviewDetailService.java
+++ b/src/main/java/com/booklog/review/detail/service/ReviewDetailService.java
@@ -4,4 +4,8 @@ import com.booklog.review.detail.dto.ReviewDetail;
 
 public interface ReviewDetailService {
 	ReviewDetail findReviewDetail(String reviewId);
+	void incrementLikesCount(String reviewId);
+	void incrementScrapsCount(String reviewId);
+	void decrementLikesCount(String reviewId);
+	void decrementScrapsCount(String reviewId);
 }

--- a/src/main/java/com/booklog/review/detail/service/ReviewDetailServiceImpl.java
+++ b/src/main/java/com/booklog/review/detail/service/ReviewDetailServiceImpl.java
@@ -3,9 +3,8 @@ package com.booklog.review.detail.service;
 import org.springframework.stereotype.Service;
 
 import com.booklog.review.detail.dto.ReviewDetail;
+import com.booklog.review.detail.repository.MongoTemplateReviewDetailRepository;
 import com.booklog.review.detail.repository.ReviewDetailRepository;
-import com.booklog.review.like.service.ReviewLikeService;
-import com.booklog.review.scrap.service.ReviewScrapService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,14 +14,31 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ReviewDetailServiceImpl implements ReviewDetailService{
 	private final ReviewDetailRepository reviewDetailRepository;
-	private final ReviewLikeService reviewLikeService;
-	private final ReviewScrapService reviewScrapService;
+	private final MongoTemplateReviewDetailRepository mongoTemplateReviewDetailRepository;
 
 	@Override
 	public ReviewDetail findReviewDetail(String reviewId) {
 		return ReviewDetail.of(reviewDetailRepository.findById(reviewId)
-			.orElseThrow(() -> new RuntimeException("not find review detail by : " + reviewId)))
-			.countLikes(reviewLikeService.countLikes(reviewId))
-			.countScraps(reviewScrapService.countScraps(reviewId));
+			.orElseThrow(() -> new RuntimeException("not find review detail by : " + reviewId)));
+	}
+
+	@Override
+	public void incrementLikesCount(String reviewId) {
+		mongoTemplateReviewDetailRepository.incrementLikesCountByReviewId(reviewId);
+	}
+
+	@Override
+	public void incrementScrapsCount(String reviewId) {
+		mongoTemplateReviewDetailRepository.incrementScrapsCountByReviewId(reviewId);
+	}
+
+	@Override
+	public void decrementLikesCount(String reviewId) {
+		mongoTemplateReviewDetailRepository.decrementLikesCountByReviewId(reviewId);
+	}
+
+	@Override
+	public void decrementScrapsCount(String reviewId) {
+		mongoTemplateReviewDetailRepository.decrementScrapsCountByReviewId(reviewId);
 	}
 }

--- a/src/main/java/com/booklog/review/like/controller/ReviewLikeController.java
+++ b/src/main/java/com/booklog/review/like/controller/ReviewLikeController.java
@@ -7,37 +7,37 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.booklog.review.like.dto.ReviewIsLikedResponseDto;
+import com.booklog.review.like.dto.IsLikedReviewResponseDto;
+import com.booklog.review.like.dto.ReviewLike;
 import com.booklog.review.like.dto.ReviewLikeRequestDto;
 import com.booklog.review.like.dto.ReviewLikeResponseDto;
-import com.booklog.review.like.dto.UserReviewLike;
 import com.booklog.review.like.service.ReviewLikeService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RequestMapping("/v1/reviews")
-@RequiredArgsConstructor
 @Slf4j
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("v1/reviews/")
 public class ReviewLikeController {
 	private final ReviewLikeService reviewLikeService;
 	@GetMapping("/is-liked")
-	public ReviewIsLikedResponseDto isLiked(@RequestParam String userId, @RequestParam String reviewId){
-		log.info("is liked review {}, by user : {} ?", reviewId, userId);
-		return ReviewIsLikedResponseDto.of(reviewLikeService.isLiked(UserReviewLike.of(userId, reviewId)));
+	public IsLikedReviewResponseDto isLiked(@RequestParam String reviewId, @RequestParam String userId) {
+		log.info("is like for review {}, by user : {}", reviewId, userId);
+		return IsLikedReviewResponseDto.of(reviewLikeService.isLiked(reviewId, userId));
 	}
 
-	@PostMapping(value = "/like")
-	public ReviewLikeResponseDto likeReview(@RequestBody ReviewLikeRequestDto reviewLikeRequestDto){
-		log.info("like review : {}, by user : {}", reviewLikeRequestDto.getReviewId(), reviewLikeRequestDto.getUserId());
-		return ReviewLikeResponseDto.of(reviewLikeService.likeReview(UserReviewLike.of(reviewLikeRequestDto)));
+	@PostMapping("/like")
+	public ReviewLikeResponseDto likeReview(@RequestBody ReviewLikeRequestDto reviewLikeRequestDto) {
+		log.info("post like for review {}, by user : {}", reviewLikeRequestDto.getReviewId(), reviewLikeRequestDto.getUserId());
+		return ReviewLikeResponseDto.of(reviewLikeService.likeForReview(ReviewLike.of(reviewLikeRequestDto)));
 	}
 
-	@PostMapping(value = "/unlike")
-	public ReviewLikeResponseDto unLikeReview(@RequestBody ReviewLikeRequestDto reviewLikeRequestDto){
-		log.info("unlike review : {}, by user : {}", reviewLikeRequestDto.getReviewId(), reviewLikeRequestDto.getUserId());
-		return ReviewLikeResponseDto.of(reviewLikeService.unLikeReview(UserReviewLike.of(reviewLikeRequestDto)));
-
+	@PostMapping("/unlike")
+	public ReviewLikeResponseDto unLikeReview(@RequestBody ReviewLikeRequestDto reviewLikeRequestDto) {
+		log.info("delete like for review {}, by user : {}", reviewLikeRequestDto.getReviewId(), reviewLikeRequestDto.getUserId());
+		return ReviewLikeResponseDto.of(reviewLikeService.unlikeForReview(ReviewLike.of(reviewLikeRequestDto)));
 	}
+
 }

--- a/src/main/java/com/booklog/review/like/dto/IsLikedReviewResponseDto.java
+++ b/src/main/java/com/booklog/review/like/dto/IsLikedReviewResponseDto.java
@@ -1,0 +1,16 @@
+package com.booklog.review.like.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IsLikedReviewResponseDto {
+	private boolean liked;
+
+	public static IsLikedReviewResponseDto of(boolean liked){
+		return IsLikedReviewResponseDto.builder()
+			.liked(liked)
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/like/dto/ReviewLike.java
+++ b/src/main/java/com/booklog/review/like/dto/ReviewLike.java
@@ -1,0 +1,18 @@
+package com.booklog.review.like.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewLike {
+	private String reviewId;
+	private String userId;
+
+	public static ReviewLike of(ReviewLikeRequestDto reviewLikeRequestDto){
+		return ReviewLike.builder()
+			.reviewId(reviewLikeRequestDto.getReviewId())
+			.userId(reviewLikeRequestDto.getUserId())
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/like/dto/ReviewLikeRequestDto.java
+++ b/src/main/java/com/booklog/review/like/dto/ReviewLikeRequestDto.java
@@ -1,0 +1,9 @@
+package com.booklog.review.like.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewLikeRequestDto {
+	private String reviewId;
+	private String userId;
+}

--- a/src/main/java/com/booklog/review/like/dto/ReviewLikeResponseDto.java
+++ b/src/main/java/com/booklog/review/like/dto/ReviewLikeResponseDto.java
@@ -1,0 +1,16 @@
+package com.booklog.review.like.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewLikeResponseDto {
+	private long likesCount;
+
+	public static ReviewLikeResponseDto of(long likesCount){
+		return ReviewLikeResponseDto.builder()
+			.likesCount(likesCount)
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/like/entity/ReviewLikeEvent.java
+++ b/src/main/java/com/booklog/review/like/entity/ReviewLikeEvent.java
@@ -1,0 +1,31 @@
+package com.booklog.review.like.entity;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.booklog.review.like.dto.ReviewLike;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Document(collection = "reviewlikes")
+public class ReviewLikeEvent {
+	@Id
+	private String id;
+	private String reviewId;
+	private String userId;
+	private String likedAt;
+
+	public static ReviewLikeEvent of(ReviewLike reviewLike){
+		return ReviewLikeEvent.builder()
+			.reviewId(reviewLike.getReviewId())
+			.userId(reviewLike.getUserId())
+			.likedAt(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME))
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/like/repository/MongoRepositoryReviewLikeRepository.java
+++ b/src/main/java/com/booklog/review/like/repository/MongoRepositoryReviewLikeRepository.java
@@ -1,0 +1,12 @@
+package com.booklog.review.like.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.booklog.review.like.entity.ReviewLikeEvent;
+
+public interface MongoRepositoryReviewLikeRepository extends MongoRepository<ReviewLikeEvent, String> {
+	long countReviewLikeEventsByReviewId(String reviewId);
+	Optional<ReviewLikeEvent> findReviewLikeEventByReviewIdAndUserId(String reviewId, String userId);
+}

--- a/src/main/java/com/booklog/review/like/repository/RedisReviewLikeRepository.java
+++ b/src/main/java/com/booklog/review/like/repository/RedisReviewLikeRepository.java
@@ -1,0 +1,10 @@
+package com.booklog.review.like.repository;
+
+import com.booklog.review.like.entity.ReviewLikeEvent;
+
+public interface RedisReviewLikeRepository {
+	boolean isLikedForReviewByUserId(String reviewId, String userId);
+	void postLikeByReviewId(ReviewLikeEvent reviewLikeEvent);
+	void deleteLikeByReviewIdAndUserId(String reviewId, String userId);
+	long countLikesByReviewId(String reviewId);
+}

--- a/src/main/java/com/booklog/review/like/repository/RedisReviewLikeRepositoryImpl.java
+++ b/src/main/java/com/booklog/review/like/repository/RedisReviewLikeRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.booklog.review.like.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.booklog.review.like.entity.ReviewLikeEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisReviewLikeRepositoryImpl implements RedisReviewLikeRepository {
+	private final RedisTemplate<String, Object> redisTemplate;
+	private static final String KEY = "like:review:";
+	@Override
+	public boolean isLikedForReviewByUserId(String reviewId, String userId) {
+		return redisTemplate.opsForHash().hasKey(KEY + reviewId, userId);
+	}
+
+	@Override
+	public void postLikeByReviewId(ReviewLikeEvent reviewLikeEvent) {
+		redisTemplate.opsForHash().put(
+			KEY + reviewLikeEvent.getReviewId(),	// redis key
+			reviewLikeEvent.getUserId(), 				// hash key
+			reviewLikeEvent.getLikedAt()				// hash value
+		);
+	}
+
+	@Override
+	public void deleteLikeByReviewIdAndUserId(String reviewId, String userId) {
+		redisTemplate.opsForHash().delete(
+			KEY + reviewId,	// redis key
+			userId					// hash key
+		);
+	}
+
+	@Override
+	public long countLikesByReviewId(String reviewId) {
+		return redisTemplate.opsForHash().size(KEY + reviewId);
+	}
+}

--- a/src/main/java/com/booklog/review/like/service/ReviewLikeService.java
+++ b/src/main/java/com/booklog/review/like/service/ReviewLikeService.java
@@ -1,10 +1,11 @@
 package com.booklog.review.like.service;
 
-import com.booklog.review.like.dto.UserReviewLike;
+import com.booklog.review.like.dto.ReviewLike;
 
 public interface ReviewLikeService {
-	boolean isLiked(UserReviewLike reviewLike);
-	long likeReview(UserReviewLike reviewLike);
-	long unLikeReview(UserReviewLike reviewLike);
-	long countLikes(String reviewId);
+	boolean isLiked(String reviewId, String userId);
+
+	long likeForReview(ReviewLike reviewLike);
+
+	long unlikeForReview(ReviewLike reviewLike);
 }

--- a/src/main/java/com/booklog/review/scrap/controller/ReviewScrapController.java
+++ b/src/main/java/com/booklog/review/scrap/controller/ReviewScrapController.java
@@ -7,37 +7,37 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.booklog.review.scrap.dto.ReviewIsScrappedResponseDto;
+import com.booklog.review.scrap.dto.IsScrappedReviewResponseDto;
+import com.booklog.review.scrap.dto.ReviewScrap;
 import com.booklog.review.scrap.dto.ReviewScrapRequestDto;
 import com.booklog.review.scrap.dto.ReviewScrapResponseDto;
-import com.booklog.review.scrap.dto.UserReviewScrap;
 import com.booklog.review.scrap.service.ReviewScrapService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RequestMapping("/v1/reviews")
-@RequiredArgsConstructor
 @Slf4j
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("v1/reviews/")
 public class ReviewScrapController {
 	private final ReviewScrapService reviewScrapService;
 	@GetMapping("/is-scrapped")
-	public ReviewIsScrappedResponseDto isLiked(@RequestParam String userId, @RequestParam String reviewId){
-		log.info("is scrapped review {}, by user : {} ?", reviewId, userId);
-		return ReviewIsScrappedResponseDto.of(reviewScrapService.isScrapped(UserReviewScrap.of(userId, reviewId)));
+	public IsScrappedReviewResponseDto isScrapped(@RequestParam String reviewId, @RequestParam String userId) {
+		log.info("is scrap for review {}, by user : {}", reviewId, userId);
+		return IsScrappedReviewResponseDto.of(reviewScrapService.isScrapped(reviewId, userId));
 	}
 
-	@PostMapping(value = "/scrap")
-	public ReviewScrapResponseDto scrapReview(@RequestBody ReviewScrapRequestDto reviewScrapRequestDto){
-		log.info("scrap review : {}, by user : {}", reviewScrapRequestDto.getReviewId(), reviewScrapRequestDto.getUserId());
-		return ReviewScrapResponseDto.of(reviewScrapService.scrapReview(UserReviewScrap.of(reviewScrapRequestDto)));
+	@PostMapping("/scrap")
+	public ReviewScrapResponseDto scrapReview(@RequestBody ReviewScrapRequestDto reviewScrapRequestDto) {
+		log.info("post scrap for review {}, by user : {}", reviewScrapRequestDto.getReviewId(), reviewScrapRequestDto.getUserId());
+		return ReviewScrapResponseDto.of(reviewScrapService.scrapForReview(ReviewScrap.of(reviewScrapRequestDto)));
 	}
 
-	@PostMapping(value = "/unscrap")
-	public ReviewScrapResponseDto unScrapReview(@RequestBody ReviewScrapRequestDto reviewScrapRequestDto){
-		log.info("un scrap review : {}, by user : {}", reviewScrapRequestDto.getReviewId(), reviewScrapRequestDto.getUserId());
-		return ReviewScrapResponseDto.of(reviewScrapService.unScrapReview(UserReviewScrap.of(reviewScrapRequestDto)));
-
+	@PostMapping("/unscrap")
+	public ReviewScrapResponseDto unScrapReview(@RequestBody ReviewScrapRequestDto reviewScrapRequestDto) {
+		log.info("delete scrap for review {}, by user : {}", reviewScrapRequestDto.getReviewId(), reviewScrapRequestDto.getUserId());
+		return ReviewScrapResponseDto.of(reviewScrapService.unscrapForReview(ReviewScrap.of(reviewScrapRequestDto)));
 	}
+
 }

--- a/src/main/java/com/booklog/review/scrap/dto/IsScrappedReviewResponseDto.java
+++ b/src/main/java/com/booklog/review/scrap/dto/IsScrappedReviewResponseDto.java
@@ -1,0 +1,16 @@
+package com.booklog.review.scrap.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IsScrappedReviewResponseDto {
+	private boolean scrapped;
+
+	public static IsScrappedReviewResponseDto of(boolean scrapped){
+		return IsScrappedReviewResponseDto.builder()
+			.scrapped(scrapped)
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/scrap/dto/ReviewScrap.java
+++ b/src/main/java/com/booklog/review/scrap/dto/ReviewScrap.java
@@ -1,0 +1,18 @@
+package com.booklog.review.scrap.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewScrap {
+	private String reviewId;
+	private String userId;
+
+	public static ReviewScrap of(ReviewScrapRequestDto reviewScrapRequestDto){
+		return ReviewScrap.builder()
+			.reviewId(reviewScrapRequestDto.getReviewId())
+			.userId(reviewScrapRequestDto.getUserId())
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/scrap/dto/ReviewScrapRequestDto.java
+++ b/src/main/java/com/booklog/review/scrap/dto/ReviewScrapRequestDto.java
@@ -1,0 +1,9 @@
+package com.booklog.review.scrap.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewScrapRequestDto {
+	private String reviewId;
+	private String userId;
+}

--- a/src/main/java/com/booklog/review/scrap/entity/ReviewScrapEvent.java
+++ b/src/main/java/com/booklog/review/scrap/entity/ReviewScrapEvent.java
@@ -1,0 +1,31 @@
+package com.booklog.review.scrap.entity;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.booklog.review.scrap.dto.ReviewScrap;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Document(collection = "reviewscraps")
+public class ReviewScrapEvent {
+	@Id
+	private String id;
+	private String reviewId;
+	private String userId;
+	private String scrapedAt;
+
+	public static ReviewScrapEvent of(ReviewScrap reviewScrap){
+		return ReviewScrapEvent.builder()
+			.reviewId(reviewScrap.getReviewId())
+			.userId(reviewScrap.getUserId())
+			.scrapedAt(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME))
+			.build();
+	}
+}

--- a/src/main/java/com/booklog/review/scrap/repository/MongoRepositoryReviewScrapRepository.java
+++ b/src/main/java/com/booklog/review/scrap/repository/MongoRepositoryReviewScrapRepository.java
@@ -1,0 +1,12 @@
+package com.booklog.review.scrap.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.booklog.review.scrap.entity.ReviewScrapEvent;
+
+public interface MongoRepositoryReviewScrapRepository extends MongoRepository<ReviewScrapEvent, String> {
+	long countReviewScrapEventsByReviewId(String reviewId);
+	Optional<ReviewScrapEvent> findReviewScrapEventByReviewIdAndUserId(String reviewId, String userId);
+}

--- a/src/main/java/com/booklog/review/scrap/repository/RedisReviewScrapRepository.java
+++ b/src/main/java/com/booklog/review/scrap/repository/RedisReviewScrapRepository.java
@@ -1,0 +1,10 @@
+package com.booklog.review.scrap.repository;
+
+import com.booklog.review.scrap.entity.ReviewScrapEvent;
+
+public interface RedisReviewScrapRepository {
+	boolean isScrappedForReviewByUserId(String reviewId, String userId);
+	void postScrapByReviewId(ReviewScrapEvent reviewScrapEvent);
+	void deleteScrapByReviewIdAndUserId(String reviewId, String userId);
+	long countScrapsByReviewId(String reviewId);
+}

--- a/src/main/java/com/booklog/review/scrap/repository/RedisReviewScrapRepositoryImpl.java
+++ b/src/main/java/com/booklog/review/scrap/repository/RedisReviewScrapRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.booklog.review.scrap.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.booklog.review.scrap.entity.ReviewScrapEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisReviewScrapRepositoryImpl implements RedisReviewScrapRepository {
+	private final RedisTemplate<String, Object> redisTemplate;
+	private static final String KEY = "scrap:review:";
+	@Override
+	public boolean isScrappedForReviewByUserId(String reviewId, String userId) {
+		return redisTemplate.opsForHash().hasKey(KEY + reviewId, userId);
+	}
+
+	@Override
+	public void postScrapByReviewId(ReviewScrapEvent reviewScrapEvent) {
+		redisTemplate.opsForHash().put(
+			KEY + reviewScrapEvent.getReviewId(),	// redis key
+			reviewScrapEvent.getUserId(), 				// hash key
+			reviewScrapEvent.getScrapedAt()				// hash value
+		);
+	}
+
+	@Override
+	public void deleteScrapByReviewIdAndUserId(String reviewId, String userId) {
+		redisTemplate.opsForHash().delete(
+			KEY + reviewId,	// redis key
+			userId					// hash key
+		);
+	}
+
+	@Override
+	public long countScrapsByReviewId(String reviewId) {
+		return redisTemplate.opsForHash().size(KEY + reviewId);
+	}
+}

--- a/src/main/java/com/booklog/review/scrap/service/ReviewScrapService.java
+++ b/src/main/java/com/booklog/review/scrap/service/ReviewScrapService.java
@@ -1,10 +1,11 @@
 package com.booklog.review.scrap.service;
 
-import com.booklog.review.scrap.dto.UserReviewScrap;
+import com.booklog.review.scrap.dto.ReviewScrap;
 
 public interface ReviewScrapService {
-	boolean isScrapped(UserReviewScrap userReviewScrap);
-	long scrapReview(UserReviewScrap userReviewScrap);
-	long unScrapReview(UserReviewScrap userReviewScrap);
-	long countScraps(String reviewId);
+	boolean isScrapped(String reviewId, String userId);
+
+	long scrapForReview(ReviewScrap reviewScrap);
+
+	long unscrapForReview(ReviewScrap reviewScrap);
 }


### PR DESCRIPTION
# 리뷰 좋아요/스크랩 redis 전략 수정
1. 캐시 메모리쓰기 정책을 write back에서 write through로 수정
1-1.([[Cache] Write Through과 Write Back의 차이](https://melonicedlatte.com/computerarchitecture/2019/02/12/203749.html) 참고)
## 프로세스 
**Scrap 프로세스도 동일*
### 좋아요 여부 확인
1. redis에 reviewId, userId 별로 좋아요 한 내역이 있는지 확인
2. 있다면 true 반환, 없다면 mongo에 동일한 reviewId, userId 별로 좋아요 한 내역이 있는지 확인
3. 있다면 redis에 업데이트 후 isLiked = true로 반환
4. 없다면 isLiked = false로 반환

### 좋아요 요청
1. redis에 reviewId, userId 별로 좋아요 한 내역이 있는지 확인
2. 있다면 좋아요 수 반환
3. 없다면 redis에 userId와 likedAt(좋아요 누른 시간) 적재
4. mongo에도 동일하게 적재
5. reviewDetail의 likesCount 1 증가
6. mongo에서 reviewId별 좋아요 총 수 반환

### 좋아요 취소
1. mongo에 reviewId, userId 별로 좋아요 한 내역이 있는지 확인
2. 있다면 레디스 제거, mongo제거 ,reviewDeatil의 likesCount 1 감소
3. mongo에서 reviewId별 좋아요 총 수 반환
